### PR TITLE
Use HTTPS for git.io requests

### DIFF
--- a/.functions
+++ b/.functions
@@ -97,7 +97,7 @@ gitio() {
 		echo "Usage: \`gitio slug url\`"
 		return 1
 	fi
-	curl -i http://git.io/ -F "url=${2}" -F "code=${1}"
+	curl -i https://git.io/ -F "url=${2}" -F "code=${1}"
 }
 
 # Start an HTTP server from a directory, optionally specifying the port


### PR DESCRIPTION
The git.io service use https instead of http.

A http request results in a "301 Moved Permanently" redirect error.