### PR TITLE
Avoid infinite recursion when Docker isn't in $PATH

### DIFF
--- a/.dockerfunc
+++ b/.dockerfunc
@@ -1009,7 +1009,7 @@ alias yubico-piv-tool="yubico_piv_tool"
 ###
 ### Awesome sauce by @jpetazzo
 ###
-if command -v "docker"; then
+if command -v "docker" &>/dev/null; then
 	command_not_found_handle () {
 		# Check if there is a container image with that name
 		if ! docker inspect --format '{{ .Author }}' "$1" >&/dev/null ; then

--- a/.dockerfunc
+++ b/.dockerfunc
@@ -1009,26 +1009,28 @@ alias yubico-piv-tool="yubico_piv_tool"
 ###
 ### Awesome sauce by @jpetazzo
 ###
-command_not_found_handle () {
-	# Check if there is a container image with that name
-	if ! docker inspect --format '{{ .Author }}' "$1" >&/dev/null ; then
-		echo "$0: $1: command not found"
-		return
-	fi
+if command -v "docker"; then
+	command_not_found_handle () {
+		# Check if there is a container image with that name
+		if ! docker inspect --format '{{ .Author }}' "$1" >&/dev/null ; then
+			echo "$0: $1: command not found"
+			return
+		fi
 
-	# Check that it's really the name of the image, not a prefix
-	if docker inspect --format '{{ .Id }}' "$1" | grep -q "^$1" ; then
-		echo "$0: $1: command not found"
-		return
-	fi
+		# Check that it's really the name of the image, not a prefix
+		if docker inspect --format '{{ .Id }}' "$1" | grep -q "^$1" ; then
+			echo "$0: $1: command not found"
+			return
+		fi
 
-	docker run -ti -u "$(whoami)" -w "$HOME" \
-		"$(env | cut -d= -f1 | awk '{print "-e", $1}')" \
-		--device /dev/snd \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
-		-v /etc/localtime:/etc/localtime:ro \
-		-v /home:/home \
-		-v /tmp/.X11-unix:/tmp/.X11-unix \
-		"${DOCKER_REPO_PREFIX}/${1}" "$@"
-}
+		docker run -ti -u "$(whoami)" -w "$HOME" \
+			"$(env | cut -d= -f1 | awk '{print "-e", $1}')" \
+			--device /dev/snd \
+			-v /etc/passwd:/etc/passwd:ro \
+			-v /etc/group:/etc/group:ro \
+			-v /etc/localtime:/etc/localtime:ro \
+			-v /home:/home \
+			-v /tmp/.X11-unix:/tmp/.X11-unix \
+			"${DOCKER_REPO_PREFIX}/${1}" "$@"
+	}
+fi


### PR DESCRIPTION
This was a fun hour! My `.bashrc` was making another call that didn't exist, which hit this hook, and Docker wasn't installed yet, so it called itself. Thus I ran out of memory within a couple minutes of logging in. That's what I get for setting up my dotfiles over SSH, I guess. Judicious use of `killall -9 bash` long enough to make another user was my only way out.

Anyway, this doesn't register the hook if `docker` isn't in `$PATH`.