### PR TITLE
Add dirmngr to bootstraping packages

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -24,6 +24,7 @@ setup_sources() {
 		apt-transport-https \
 		ca-certificates \
 		curl \
+		dirmngr \
 		--no-install-recommends
 
 	cat <<-EOF > /etc/apt/sources.list


### PR DESCRIPTION
It appears the strech no longer packages `dirmngr` by default. To work with the gpg keys it is needed.