### PR TITLE
Remove redundant bash completion sourcing

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -91,10 +91,10 @@ if ! shopt -oq posix; then
 		. /etc/bash_completion
 	fi
 fi
-for file in /etc/bash_completion.d/* ; do
-	# shellcheck source=/dev/null
-	source "$file"
-done
+#for file in /etc/bash_completion.d/* ; do
+#	# shellcheck source=/dev/null
+#	source "$file"
+#done
 
 if [[ -f "${HOME}/.bash_profile" ]]; then
 	# shellcheck source=/dev/null


### PR DESCRIPTION
The redundant check causes errors on my machine(s) under Ubuntu and Debian at least when using a display manager.
`/etc/bash_completion` on my system just sources `/usr/share/bash-completion/bash_completion` which does the same loop over files in `/etc/bash_completion.d`, and doing it a second time seems to trigger a major terminal slowdown as well as occasional errors when it sees a completion is already set or maybe it is a race condition within the code.

If it was instead looking for [ -f "$(brew --prefix)/etc/bash_completion.d" ] and sourcing the files, it might make a little more sense as this should work with Linuxbrew and Homebrew. I could test that change at some point as I do have access to a Mac and Linux machines.