### PR TITLE
Make dmesg readable by users again

### DIFF
--- a/etc/sysctl.d/local-sysctl.conf
+++ b/etc/sysctl.d/local-sysctl.conf
@@ -1,0 +1,5 @@
+# Increase virtual memory map areas
+vm.max_map_count=262144
+
+# Enable dmesg for 'normal' users
+kernel.dmesg_restrict=0


### PR DESCRIPTION
After upgrading dmesg, a change of security settings made it no longer readable for 'normal' users. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=842226#10

With a config param it can be enabled again.
I created a separate `local-sysctl.conf` file because there was no sysctl.conf in your (and my) dotfiles so it won't override current settings.
The `vm.max_map_count` param was needed by some of the containers I'm running. I guess you can remove it if you don't need the setting.