### PR TITLE
Multimedia keys did not work with amixer

### DIFF
--- a/.i3/config
+++ b/.i3/config
@@ -137,8 +137,8 @@ bindsym $mod+Shift+9 move container to workspace 9
 bindsym $mod+Shift+0 move container to workspace 10
 
 # audio controls
-bindsym XF86AudioRaiseVolume exec amixer set Master 5+ #increase sound volume
-bindsym XF86AudioLowerVolume exec amixer set Master 5- #decrease sound volume
+bindsym XF86AudioRaiseVolume exec amixer set Master 5%+ #increase sound volume
+bindsym XF86AudioLowerVolume exec amixer set Master 5%- #decrease sound volume
 bindsym XF86AudioMute exec amixer set Master 1+ toggle # mute sound
 bindsym XF86AudioMicMute exec amixer set Capture toggle # mute mic
 


### PR DESCRIPTION
I'm on a Thinkpad T420 using Debian Stretch and the volume up/down multimedia keys weren't working for me.
```
drew@drew-thinkpad:~/.config/i3$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 9.1 (stretch)
Release:	9.1
Codename:	stretch

drew@drew-thinkpad:~/.config/i3$ amixer -v
amixer version 1.1.3

drew@drew-thinkpad:~/.config/i3$ amixer scontrols
Simple mixer control 'Master',0
Simple mixer control 'Capture',0
```

I'm not sure if this is a YMMV situation, but according to the amixer manpage the set/sset command requires % or dB:
```
set or sset <SCONTROL> <PARAMETER> ...

Sets  the  simple mixer control contents. The parameter can be the
volume either as a percentage from 0% to 100% with % suffix, a  dB
gain  with  dB  suffix (like -12.5dB), or an exact hardware value.
```