### PR TITLE
Make test script compatible with alpine

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ set -o pipefail
 ERRORS=()
 
 # find all executables and run `shellcheck`
-for f in $(find . -type f -not -iwholename '*.git*' -not -name "yubitouch.sh" | sort -u); do
+for f in $(find . -type f -not -path '*.git*' -not -name "yubitouch.sh" | sort -u); do
 	if file "$f" | grep --quiet shell; then
 		{
 			shellcheck "$f" && echo "[OK]: successfully linted $f"


### PR DESCRIPTION
find -iwholename argument does not exist on alpine. Replace with -path which accomplishes same functionality :)