### PR TITLE
Remove dup setting of GPG_TTY

### DIFF
--- a/.exports
+++ b/.exports
@@ -33,11 +33,5 @@ export GO15VENDOREXPERIMENT=1
 
 export DOCKER_CONTENT_TRUST=1
 
-# if it's an ssh session export GPG_TTY
-if [[ -n "$SSH_CLIENT" ]] || [[ -n "$SSH_TTY" ]]; then
-	GPG_TTY=$(tty)
-	export GPG_TTY
-fi
-
 # set xdg data dirs for dmenu to source
 export XDG_DATA_DIRS=/usr/share/


### PR DESCRIPTION
As it’s unconditionally set here:
https://github.com/jessfraz/dotfiles/blob/d8db5f055252a9f86181cee71cea29f68015d606/.bashrc#L111