### PR TITLE
Fix prompt to work where GIT_DIR is not /.git

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -23,7 +23,7 @@ prompt_git() {
 		# check if the current directory is in .git before running git checks
 		if [ "$(git rev-parse --is-inside-git-dir 2> /dev/null)" == 'false' ]; then
 
-			if [[ -O "$(git rev-parse --show-toplevel)/.git/index" ]]; then
+			if [[ -O "$(git rev-parse --git-dir)/index" ]]; then
 				git update-index --really-refresh -q &> /dev/null;
 			fi;
 


### PR DESCRIPTION
e.g., [yadm](https://github.com/TheLocehiliosan/yadm) 2.x uses `~/.config/yadm/repo.git`. yadm 3.x uses `~/.local/share/yadm/repo.git`