### PR TITLE
faster git prompt

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -14,54 +14,16 @@ elif infocmp xterm-256color >/dev/null 2>&1; then
 fi;
 
 prompt_git() {
-	local s='';
-	local branchName='';
-
-	# Check if the current directory is in a Git repository.
-	if [ "$(git rev-parse --is-inside-work-tree &>/dev/null; echo "${?}")" == '0' ]; then
-
-		# check if the current directory is in .git before running git checks
-		if [ "$(git rev-parse --is-inside-git-dir 2> /dev/null)" == 'false' ]; then
-
-			if [[ -O "$(git rev-parse --show-toplevel)/.git/index" ]]; then
-				git update-index --really-refresh -q &> /dev/null;
-			fi;
-
-			# Check for uncommitted changes in the index.
-			if ! git diff --quiet --ignore-submodules --cached; then
-				s+='+';
-			fi;
-
-			# Check for unstaged changes.
-			if ! git diff-files --quiet --ignore-submodules --; then
-				s+='!';
-			fi;
-
-			# Check for untracked files.
-			if [ -n "$(git ls-files --others --exclude-standard)" ]; then
-				s+='?';
-			fi;
-
-			# Check for stashed files.
-			if git rev-parse --verify refs/stash &>/dev/null; then
-				s+='$';
-			fi;
-
-		fi;
-
-		# Get the short symbolic ref.
-		# If HEAD isn’t a symbolic ref, get the short SHA for the latest commit
-		# Otherwise, just give up.
-		branchName="$(git symbolic-ref --quiet --short HEAD 2> /dev/null || \
-			git rev-parse --short HEAD 2> /dev/null || \
-			echo '(unknown)')";
-
-		[ -n "${s}" ] && s=" [${s}]";
-
-		echo -e "${1}${branchName}${blue}${s}";
-	else
-		return;
-	fi;
+    local gs='' s='' branch='';
+    gs=$(git status --show-stash 2>&1) || return;
+    branch=$(echo "$gs" | head -n1)
+    branch=${branch#"On branch "}
+    [[ "$gs" =~ "Changes to be committed:" ]] && s+="+";
+    [[ "$gs" =~ "Changes not staged for commit:" ]] && s+="!";
+    [[ "$gs" =~ "Untracked files" ]] && s+="?";
+    [[ "$gs" =~ "Your stash currently has" ]] && s+="$";
+    [ -n "${s}" ] && s=" [${s}]";
+    echo -e "${1}${branch}${blue}${s}";
 }
 
 cloud=""

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -16,8 +16,7 @@ fi;
 prompt_git() {
     local gs='' s='' branch='';
     gs=$(git status --show-stash 2>&1) || return;
-    branch=$(echo "$gs" | head -n1)
-    branch=${branch#"On branch "}
+    [[ "$gs" =~ On\ branch\ ([[:print:]]*) ]] && branch=${BASH_REMATCH[1]} # credit @rasa. see https://github.com/jessfraz/dotfiles/pull/38#discussion_r382945541
     [[ "$gs" =~ "Changes to be committed:" ]] && s+="+";
     [[ "$gs" =~ "Changes not staged for commit:" ]] && s+="!";
     [[ "$gs" =~ "Untracked files" ]] && s+="?";


### PR DESCRIPTION
On my env (fast laptop but WSL - which doesn't play nice with git) the current `prompt_git` was taking around 100ms, which was noticeable. Parsing `git status` is kinda nasty, but it seems to work and only takes 30ms. More of an FYI - feel free to reject etc.